### PR TITLE
Make image scaling opt-in instead of opt-out

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "license": "Artistic-1.0-Perl",
     "maintainer": "Flywheel <support@flywheel.io>",
     "source": "https://github.com/flywheel-apps/Bru2Nii",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "flywheel": "0",
     "command": "./run.py",
     "inputs": {
@@ -20,16 +20,16 @@
         }
     },
     "config": {
-        "actual_size": {
+        "scale_size": {
             "type": "boolean",
-            "description": "Actual size (otherwise x10 scale so animals match humans)",
+            "description": "Scale size (x10) so animals match humans",
             "default": false
         }
     },
     "custom": {
-        "docker-image": "flywheel/bru2nii:0.1.0",
+        "docker-image": "flywheel/bru2nii:0.1.1",
         "gear-builder": {
-            "image": "flywheel/bru2nii:0.1.0"
+            "image": "flywheel/bru2nii:0.1.1"
         }
     }
 }

--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
             '-f',   # force conversion of localizer images (multiple slice orientations)
             '-z',   # gz compress images (".nii.gz")
         ]
-        if context.config.get('actual_size'):
+        if not context.config.get('scale_size'):
             cmd.append('-a')  # actual size (otherwise x10 scale so animals match humans)
         output_filename = re.sub(r'\.pv\d\.zip$', '', input_filename)
         output_filepath = os.path.join(context.output_dir, output_filename)


### PR DESCRIPTION
I assumed `Bru2Nii`'s defaults (x10 scale img) are what users in the bruker domain want.
Turns out that's false - changing the setting to opt-in instead of opt-out.